### PR TITLE
Kerberos AES: Encode password as UTF-8

### DIFF
--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -435,6 +435,8 @@ class _AESEnctype(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         (iterations,) = unpack('>L', params or b'\x00\x00\x10\x00')
         prf = lambda p, s: HMAC.new(p, s, SHA).digest()
+        if isinstance(string, str):
+            string = string.encode("utf-8")
         seed = PBKDF2(string, salt, cls.seedsize, iterations, prf)
         tkey = cls.random_to_key(seed)
         return cls.derive(tkey, b'kerberos')


### PR DESCRIPTION
Using getKerberosTGT with a password that has non-latin-1 characters fails with

  File "/usr/lib/python3/dist-packages/impacket/krb5/kerberosv5.py", line 249, in getKerberosTGT
    key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
  File "/usr/lib/python3/dist-packages/impacket/krb5/crypto.py", line 441, in string_to_key
    seed = PBKDF2(string, salt, cls.seedsize, iterations, prf)
  File "/usr/lib/python3/dist-packages/Cryptodome/Protocol/KDF.py", line 140, in PBKDF2
    password = tobytes(password)
  File "/usr/lib/python3/dist-packages/Cryptodome/Util/py3compat.py", line 130, in tobytes
    return s.encode(encoding)
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 0-127: ordinal not in range(256)


As string_to_key from _RC4 expects a string (calls encode), string_to_key for AES should expect the same and do proper UTF-8 encoding as per MS-KILE.